### PR TITLE
Build Releases with GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Create
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create -d $(date '+%Y.%m')
+        run: gh release create -d "$(date '+%Y.%m')"
   release:
     name: Build and Upload
     needs: create_release
@@ -41,11 +41,11 @@ jobs:
       if: startsWith(runner.os, 'Windows')
       run: |
         mv egads.exe egads_${{ runner.os }}.exe
-        gh release upload $(date '+%Y.%m') egads_${{ runner.os }}.exe
+        gh release upload "$(date '+%Y.%m')" egads_${{ runner.os }}.exe
     - name: Release (Not Windows)
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: ${{ ! startsWith(runner.os, 'Windows') }}
       run: |
         mv egads egads_${{ runner.os }}
-        gh release upload $(date '+%Y.%m') egads_${{ runner.os }}
+        gh release upload "$(date '+%Y.%m')" egads_${{ runner.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, ubuntu-latest, windows-latest]
+        platform: [macos-latest, ubuntu-20.04, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout egads

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,17 @@ jobs:
         "C:\msys64\usr\bin\" | Out-File -FilePath $env:GITHUB_PATH -Append
     - name: Makefile
       run: make -C src
-    - name: Rename (Windows)
-      if: startsWith(runner.os, 'Windows')
-      run: mv egads.exe egads_${{ runner.os }}.exe
-    - name: Rename (Not Windows)
-      if: ${{ ! startsWith(runner.os, 'Windows') }}
-      run: mv egads egads_${{ runner.os }}
-    - name: Release
+    - name: Release (Windows)
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release upload "draft" egads_${{ runner.os }}
-
+      if: startsWith(runner.os, 'Windows')
+      run: |
+        mv egads.exe egads_${{ runner.os }}.exe
+        gh release upload "draft" egads_${{ runner.os }}.exe
+    - name: Release (Not Windows)
+      env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ ! startsWith(runner.os, 'Windows') }}
+      run: |
+        mv egads egads_${{ runner.os }}
+        gh release upload "draft" egads_${{ runner.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Create
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create -d "$(date '+%Y.%m')"
+        run: gh release create -d "v$(date '+%Y.%m')"
   release:
     name: Build and Upload
     needs: create_release
@@ -41,11 +41,11 @@ jobs:
       if: startsWith(runner.os, 'Windows')
       run: |
         mv egads.exe egads_${{ runner.os }}.exe
-        gh release upload "$(date '+%Y.%m')" egads_${{ runner.os }}.exe
+        gh release upload "v$(date '+%Y.%m')" egads_${{ runner.os }}.exe
     - name: Release (Not Windows)
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: ${{ ! startsWith(runner.os, 'Windows') }}
       run: |
         mv egads egads_${{ runner.os }}
-        gh release upload "$(date '+%Y.%m')" egads_${{ runner.os }}
+        gh release upload "v$(date '+%Y.%m')" egads_${{ runner.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, ubuntu-18.04, windows-latest]
+        platform: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout egads

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        #platform: [macos-latest, ubuntu-latest, windows-latest]
-        platform: [windows-latest]
+        platform: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout egads

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Create Draft Release
+name: Create Release
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,14 @@ jobs:
         "C:\msys64\usr\bin\" | Out-File -FilePath $env:GITHUB_PATH -Append
     - name: Makefile
       run: make -C src
+    - name: Rename (Windows)
+      if: startsWith(runner.os, 'Windows')
+      run: mv egads.exe egads_${{ runner.os }}.exe
+    - name: Rename (Not Windows)
+      if: ${{ ! startsWith(runner.os, 'Windows') }}
+      run: mv egads egads_${{ runner.os }}
     - name: Release
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        ls
-        mv egads egads_${{ runner.os }}
-        gh release upload "draft" egads_${{ runner.os }}
+      run: gh release upload "draft" egads_${{ runner.os }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, ubuntu-20.04, windows-latest]
+        platform: [macos-latest, ubuntu-18.04, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout egads

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,5 +42,6 @@ jobs:
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        ls
         mv egads egads_${{ runner.os }}
         gh release upload "draft" egads_${{ runner.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Create
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create -d "v$(date '+%Y.%m')" -t "v$(date '+%Y.%m')"
+        run: gh release create "v$(date '+%Y.%m')" -t "v$(date '+%Y.%m')"
   release:
     name: Build and Upload
     needs: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,8 @@ name: Create Draft Release
 
 on:
   workflow_dispatch:
-  #push:
-  #  branches: [ "main" ]
-  #pull_request:
-  #  branches: [ "main" ]
+  # schedule:
+  #   - cron: "0 0 1 */6 *"
 
 jobs:
   create_release:
@@ -17,7 +15,7 @@ jobs:
       - name: Create
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create -d "draft"
+        run: gh release create -d $(date '+%Y.%m')
   release:
     name: Build and Upload
     needs: create_release
@@ -43,11 +41,11 @@ jobs:
       if: startsWith(runner.os, 'Windows')
       run: |
         mv egads.exe egads_${{ runner.os }}.exe
-        gh release upload "draft" egads_${{ runner.os }}.exe
+        gh release upload $(date '+%Y.%m') egads_${{ runner.os }}.exe
     - name: Release (Not Windows)
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: ${{ ! startsWith(runner.os, 'Windows') }}
       run: |
         mv egads egads_${{ runner.os }}
-        gh release upload "draft" egads_${{ runner.os }}
+        gh release upload $(date '+%Y.%m') egads_${{ runner.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Create
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create -d "v$(date '+%Y.%m')"
+        run: gh release create -d "v$(date '+%Y.%m')" -t "v$(date '+%Y.%m')"
   release:
     name: Build and Upload
     needs: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Create Draft Release
 
 on:
   workflow_dispatch:
-  # schedule:
-  #   - cron: "0 0 1 */6 *"
+  schedule:
+    - cron: "0 0 1 */6 *"
 
 jobs:
   create_release:

--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@ Electronically Guided Digestion Selection - A ddRAD-seq enzyme selection aid
 
 ## Installation
 
+Install `egads` from this repository with the following command.
+
 ``` sh
 git clone --recursive https://github.com/IGBB/egads
 make -C egads/src
 ```
+
+Binary releases for Windows, macOS, and Linux are available 
+[on the Releases page](https://github.com/igbb/egads/releases) and are released 
+every six months to account for potential updates to the enzyme database.
 
 ## Running
 

--- a/src/enzyme.c
+++ b/src/enzyme.c
@@ -4,6 +4,11 @@
 #include <string.h>
 #include <stdlib.h>
 
+#ifdef _WIN32
+FILE *fmemopen(void *buf, size_t len, const char *type);
+#include "fmemopen.c"
+#endif
+
 #include "klib/kstring.h"
 
 #define INCBIN_PREFIX incbin_

--- a/src/enzyme.c
+++ b/src/enzyme.c
@@ -4,6 +4,8 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include "klib/kstring.h"
+
 #define INCBIN_PREFIX incbin_
 #define INCBIN_STYLE INCBIN_STYLE_SNAKE
 #define INCBIN_SILENCE_BITCODE_WARNING
@@ -68,9 +70,7 @@ char* strtok2(char* string, char token){
 
 enzyme_list_t* load_enzymes(char* input, char** names, int len){
     int i;
-    char *s = NULL;
-    size_t slen = 0;
-    ssize_t rlen;
+    kstring_t s = { 0, 0, NULL };
 
     /* Open enzyme file. If file isn't provided, open mem stream to saved
      * restriction enzymes */
@@ -93,13 +93,13 @@ enzyme_list_t* load_enzymes(char* input, char** names, int len){
     enzyme_list_t * list = enzyme_list_init();
 
     /* read each line in enzyme database */
-    while((rlen = getline(&s, &slen, file)) != -1 ){
+    for (s.l = 0; kgetline(&s, (kgets_func *)fgets, file) == 0; s.l = 0){
 
         /* skip lines that begin with space */
-        if(s[0] == ' ') continue;
+        if(ks_str(&s)[0] == ' ') continue;
 
         /* get name (first column) */
-        char * name = strtok2(s, ';');
+        char * name = strtok2(ks_str(&s), ';');
 
         enzyme_t * e;
 
@@ -187,7 +187,7 @@ enzyme_list_t* load_enzymes(char* input, char** names, int len){
 
     }
 
-    free(s);
+    free(s.s);
 
     fclose(file);
 

--- a/src/fmemopen.c
+++ b/src/fmemopen.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017  Joachim Nilsson <troglobit@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <io.h>
+#include <fcntl.h>
+#include <windows.h>
+FILE *fmemopen(void *buf, size_t len, const char *type)
+{
+	int fd;
+	FILE *fp;
+	char tp[MAX_PATH - 13];
+	char fn[MAX_PATH + 1];
+	HANDLE h;
+
+	if (!GetTempPath(sizeof(tp), tp))
+		return NULL;
+
+	if (!GetTempFileName(tp, "confuse", 0, fn))
+		return NULL;
+
+	h = CreateFile(fn, GENERIC_READ | GENERIC_WRITE, 0, NULL,
+		       CREATE_ALWAYS, FILE_FLAG_DELETE_ON_CLOSE, NULL);
+	if (INVALID_HANDLE_VALUE == h)
+		return NULL;
+
+	fd = _open_osfhandle((intptr_t)h, _O_APPEND);
+	if (fd < 0) {
+		CloseHandle(h);
+		return NULL;
+	}
+
+	fp = fdopen(fd, "w+");
+	if (!fp) {
+		CloseHandle(h);
+		return NULL;
+	}
+
+	fwrite(buf, len, 1, fp);
+	rewind(fp);
+
+	return fp;
+}

--- a/src/makefile
+++ b/src/makefile
@@ -30,6 +30,6 @@ html.o : html/d3.v5.min.js html/draw.d3.css html/draw.gel.js html/draw.html html
 main.o : restrict.o enzyme.o sequence.o html.o
 
 
-$(PROG): main.o restrict.o enzyme.o sequence.o counts.o html.o args.o
+$(PROG): main.o restrict.o enzyme.o sequence.o counts.o html.o args.o klib/kstring.o
 	$(CC) -o $@ $^ $(CFLAGS) -lz
 # end


### PR DESCRIPTION
This PR adds a workflow `release.yml` that builds `egads` releases for Windows, macOS, and Linux and uploads them to a draft release. To support building on Windows, `enzyme.c` was changed to use `kgetline()` instead of `getline()`, and `fmemopen()` was vendored from [here](https://github.com/libconfuse/libconfuse/blob/38d637245729096c301c801db9813ba69ee1542f/src/fmemopen.c#L104).